### PR TITLE
Fix compilation on Ubuntu 22.04.

### DIFF
--- a/code/tools/QgenMain.c
+++ b/code/tools/QgenMain.c
@@ -68,7 +68,7 @@ int g_nQueryNumber,
 StringBuffer_t *g_sbTemplateName = NULL;
 
 
-int yydebug;
+extern int yydebug;
 int yyparse(void);
 extern FILE *yyin;
 extern 	file_ref_t *pCurrentFile;

--- a/code/tools/QgenMain.c
+++ b/code/tools/QgenMain.c
@@ -68,7 +68,7 @@ int g_nQueryNumber,
 StringBuffer_t *g_sbTemplateName = NULL;
 
 
-extern int yydebug;
+int yydebug;
 int yyparse(void);
 extern FILE *yyin;
 extern 	file_ref_t *pCurrentFile;

--- a/code/tools/makefile
+++ b/code/tools/makefile
@@ -55,7 +55,7 @@ CC		= $($(OS)_CC)
 # CFLAGS
 AIX_CFLAGS		= -q64 -O3 -D_LARGE_FILES
 HPUX_CFLAGS		= -O3 -Wall
-LINUX_CFLAGS	= -g -Wall
+LINUX_CFLAGS	= -g -Wall -fcommon
 NCR_CFLAGS		= -g 
 SOLARIS_CFLAGS	= -O3 -Wall
 SOL86_CFLAGS	= -O3 

--- a/code/tools/s_catalog_order.c
+++ b/code/tools/s_catalog_order.c
@@ -53,7 +53,7 @@
 struct S_CATALOG_ORDER_TBL g_s_catalog_order;
 struct S_CATALOG_ORDER_LINEITEM_TBL g_s_catalog_order_lineitem;
 struct S_CATALOG_RETURNS_TBL	g_s_catalog_return;
-int nItemIndex;
+int g_s_catalog_order_nItemIndex;
 
 /*
 * Routine: 
@@ -133,7 +133,7 @@ mk_s_catalog_order(void *pDest, ds_key_t kIndex)
    int i;
 
    mk_master(pDest, kIndex);
-   genrand_integer(&nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_CLIN_ITEM_ID);
+   genrand_integer(&g_s_catalog_order_nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_CLIN_ITEM_ID);
 	for (i=1; i <= 9; i++)
 	{
       mk_detail(&g_s_catalog_order_lineitem, i, 1);
@@ -219,7 +219,7 @@ vld_s_catalog_order(int nTable, ds_key_t kRow, int* bPermutation)
 
    mk_master(NULL, kRow);
    genrand_integer(&nLineitem, DIST_UNIFORM, 1, 9, 0, S_CLIN_LINE_NUMBER);
-   genrand_integer(&nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_CLIN_ITEM_ID);
+   genrand_integer(&g_s_catalog_order_nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_CLIN_ITEM_ID);
    for (i=1; i < nLineitem; i++)
       mk_detail(&g_s_catalog_order_lineitem, i, 0);
    print_start(S_CATALOG_ORDER_LINEITEM);

--- a/code/tools/s_catalog_order_lineitem.c
+++ b/code/tools/s_catalog_order_lineitem.c
@@ -53,7 +53,7 @@
 
 extern struct S_CATALOG_ORDER_LINEITEM_TBL g_s_catalog_order_lineitem;
 extern struct S_CATALOG_ORDER_TBL g_s_catalog_order;
-extern int nItemIndex;
+extern int g_s_catalog_order_nItemIndex;
 
 /*
 * Routine:
@@ -97,14 +97,14 @@ mk_s_catalog_order_lineitem(void *pDest, ds_key_t kIndex)
 
 	r->kOrderID = g_s_catalog_order.kID;
 	r->kLineNumber = kIndex;
-   nItemIndex += 1;
-   if (nItemIndex > getIDCount(ITEM))
-      nItemIndex = 1;
+   g_s_catalog_order_nItemIndex += 1;
+   if (g_s_catalog_order_nItemIndex > getIDCount(ITEM))
+      g_s_catalog_order_nItemIndex = 1;
 
    /*
     * select a unique item, and then map to the appropriate business key
 	*/
-	r->kItemID = getPermutationEntry(pItemPermutation, nItemIndex);
+	r->kItemID = getPermutationEntry(pItemPermutation, g_s_catalog_order_nItemIndex);
 	r->kItemID = getFirstSK(r->kItemID);
 
 	r->kPromotionID = mk_join(S_CLIN_PROMOTION_ID, PROMOTION, 1);

--- a/code/tools/s_catalog_page.c
+++ b/code/tools/s_catalog_page.c
@@ -48,7 +48,7 @@
 #include "validate.h"
 #include "parallel.h"
 
-struct CATALOG_PAGE_TBL g_w_catalog_page;
+extern struct CATALOG_PAGE_TBL g_w_catalog_page;
 
 int
 mk_s_catalog_page(void *pDest, ds_key_t kRow)

--- a/code/tools/s_pline.c
+++ b/code/tools/s_pline.c
@@ -51,7 +51,7 @@
 
 struct S_PURCHASE_LINEITEM_TBL g_s_pline;
 extern struct S_PURCHASE_TBL g_s_purchase;
-extern int nItemIndex;
+extern int g_s_purchase_nItemIndex;
 
 /*
 * Routine:
@@ -99,15 +99,15 @@ mk_s_pline(void *pDest, ds_key_t kIndex)
 
 	r->kPurchaseID = g_s_purchase.kID;
 	r->kLineNumber = kIndex;
-   nItemIndex += 1;
-   if (nItemIndex > nItemIDCount)
-      nItemIndex = 1;
+   g_s_purchase_nItemIndex += 1;
+   if (g_s_purchase_nItemIndex > nItemIDCount)
+      g_s_purchase_nItemIndex = 1;
 
 	/*
     * pick the next entry in the permutation, to assure uniqueness within order
     * shift to SK value to align with printID() expectations
     */
-   r->kItemID = getPermutationEntry(pItemPermutation, nItemIndex);
+   r->kItemID = getPermutationEntry(pItemPermutation, g_s_purchase_nItemIndex);
    r->kItemID = getFirstSK(r->kItemID);
 
 	r->kPromotionID = mk_join(S_PLINE_PROMOTION_ID, PROMOTION, 1);

--- a/code/tools/s_purchase.c
+++ b/code/tools/s_purchase.c
@@ -52,7 +52,7 @@
 struct S_PURCHASE_TBL g_s_purchase;
 struct S_PURCHASE_LINEITEM_TBL g_s_purchase_lineitem;
 struct S_STORE_RETURNS_TBL g_s_store_return;
-int nItemIndex;
+int g_s_purchase_nItemIndex;
 
 /*
 * Routine: 
@@ -165,7 +165,7 @@ mk_s_purchase(void *pDest, ds_key_t kIndex)
    int i;
 
    mk_master(pDest, kIndex);
-   genrand_integer(&nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_PLINE_ITEM_ID);
+   genrand_integer(&g_s_purchase_nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_PLINE_ITEM_ID);
 	for (i=1; i <= 12; i++)
 	{
       mk_detail(i, 1);
@@ -213,7 +213,7 @@ vld_s_purchase(int nTable, ds_key_t kRow, int* bPermutation)
 
    mk_master(NULL, kRow);
    genrand_integer(&nLineitem, DIST_UNIFORM, 1, 12, 0, S_PLINE_NUMBER);
-   genrand_integer(&nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_PLINE_ITEM_ID);
+   genrand_integer(&g_s_purchase_nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_PLINE_ITEM_ID);
    for (i=1; i < nLineitem; i++)
       mk_detail(i, 0);
    print_start(S_PURCHASE_LINEITEM);

--- a/code/tools/s_warehouse.c
+++ b/code/tools/s_warehouse.c
@@ -48,7 +48,7 @@
 #include "permute.h"
 #include "scaling.h"
 
-struct W_WAREHOUSE_TBL g_w_warehouse;
+extern struct W_WAREHOUSE_TBL g_w_warehouse;
 
 /*
 * Routine: 

--- a/code/tools/s_web_order.c
+++ b/code/tools/s_web_order.c
@@ -53,7 +53,7 @@
 struct S_WEB_ORDER_TBL g_s_web_order;
 struct S_WEB_ORDER_LINEITEM_TBL g_s_web_order_lineitem;
 struct S_WEB_RETURNS_TBL g_s_web_return;
-int nItemIndex = -1;
+int g_s_web_order_nItemIndex = -1;
 
 /* now build/print the lineitems for this order */
 /* for each lineitem, randomly determine if it is to be returned */
@@ -137,7 +137,7 @@ mk_s_web_order(void *pDest, ds_key_t kIndex)
    int i;
 
    mk_master(pDest, kIndex);
-   genrand_integer(&nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_WLIN_ITEM_ID);
+   genrand_integer(&g_s_web_order_nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_WLIN_ITEM_ID);
 	for (i=1; i <= 12; i++)
 	{
       mk_detail(i, 1);
@@ -225,7 +225,7 @@ vld_s_web_order(int nTable, ds_key_t kRow, int* bPermutation)
 
    mk_master(NULL, kRow);
    genrand_integer(&nLineitem, DIST_UNIFORM, 1, 12, 0, S_WLIN_LINE_NUMBER);
-   genrand_integer(&nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_WLIN_ITEM_ID);
+   genrand_integer(&g_s_web_order_nItemIndex, DIST_UNIFORM, 1, (int)getIDCount(ITEM), 0, S_WLIN_ITEM_ID);
    for (i=1; i < nLineitem; i++)
       mk_detail(i, 0);
    print_start(S_WEB_ORDER_LINEITEM);

--- a/code/tools/s_web_order_lineitem.c
+++ b/code/tools/s_web_order_lineitem.c
@@ -51,9 +51,9 @@
 #include "scaling.h"
 #include "scd.h"
 
-struct S_WEB_ORDER_LINEITEM_TBL g_s_web_order_lineitem;
+extern struct S_WEB_ORDER_LINEITEM_TBL g_s_web_order_lineitem;
 extern struct S_WEB_ORDER_TBL g_s_web_order;
-extern int nItemIndex;
+extern int g_s_web_order_nItemIndex;
 
 /*
 * Routine:
@@ -99,13 +99,13 @@ mk_s_web_order_lineitem(void *pDest, ds_key_t kIndex)
 
 	r->kOrderID = g_s_web_order.kID;
 	r->kLineNumber = kIndex;
-   if (++nItemIndex  > nItemCount)
-      nItemIndex += 1;
+   if (++g_s_web_order_nItemIndex  > nItemCount)
+      g_s_web_order_nItemIndex += 1;
 
    /*
     * select a unique item, and then map to the appropriate business key
 	*/
-	r->kItemID = getPermutationEntry(pItemPermutation, nItemIndex);
+	r->kItemID = getPermutationEntry(pItemPermutation, g_s_web_order_nItemIndex);
 	r->kItemID = getFirstSK(r->kItemID);
 
 	r->kPromotionID = mk_join(S_WLIN_PROMOTION_ID, PROMOTION, 1);

--- a/code/tools/s_web_site.c
+++ b/code/tools/s_web_site.c
@@ -48,7 +48,7 @@
 #include "permute.h"
 #include "scd.h"
 
-struct W_WEB_SITE_TBL g_w_web_site;
+extern struct W_WEB_SITE_TBL g_w_web_site;
 
 
 /*

--- a/code/tools/w_customer.c
+++ b/code/tools/w_customer.c
@@ -56,10 +56,10 @@ static int * pBirthYearPermutation;
 static int * pBirthMonthPermutation;
 static int * pBirthDayPermutation;
 
-struct ATTRIBUTE_KEY_RECORD * pCountyRecord;
+struct ATTRIBUTE_KEY_RECORD * g_w_customer_pCountyRecord;
 struct ATTRIBUTE_KEY_MAP * pCustomerAddressCountyMap;
 
-struct ATTRIBUTE_KEY_RECORD * pStateRecord;
+struct ATTRIBUTE_KEY_RECORD * g_w_customer_pStateRecord;
 struct ATTRIBUTE_KEY_MAP * pCustomerAddressStateMap;
 
 struct ATTRIBUTE_KEY_MAP * pCdemoMap;
@@ -128,10 +128,10 @@ mk_w_customer (void * row, ds_key_t index)
 		// Load customer county map.
 		pCustomerAddressCountyMap = deserializeAttributeKeyMap("customer_address_county");
 		int nKey = (int)get_rowcount(CUSTOMER);
-		pCountyRecord = initializeAttributeKeyRecord(pCustomerAddressCountyMap->attributeCount, nKey);
+		g_w_customer_pCountyRecord = initializeAttributeKeyRecord(pCustomerAddressCountyMap->attributeCount, nKey);
 
 		pCustomerAddressStateMap = deserializeAttributeKeyMap("customer_address_state");
-		pStateRecord = initializeAttributeKeyRecord(pCustomerAddressStateMap->attributeCount, nKey);
+		g_w_customer_pStateRecord = initializeAttributeKeyRecord(pCustomerAddressStateMap->attributeCount, nKey);
 
 		pCdemoMap = deserializeAttributeKeyMap("customer_demographics");
 		pCdemoPermutation = makeKeyPermutation(NULL, pCdemoMap->attributeCount, C_CURRENT_CDEMO_SK);
@@ -189,10 +189,10 @@ mk_w_customer (void * row, ds_key_t index)
 	// Update information for populating joint distribution.
 	// Map customer address to county.
 	int attribute_id = pCustomerAddressCountyMap->attribute[r->c_current_addr_sk - 1];
-	updateAttributeKeyRecord(pCountyRecord, attribute_id);
+	updateAttributeKeyRecord(g_w_customer_pCountyRecord, attribute_id);
 
 	attribute_id = pCustomerAddressStateMap->attribute[r->c_current_addr_sk - 1];
-	updateAttributeKeyRecord(pStateRecord, attribute_id);
+	updateAttributeKeyRecord(g_w_customer_pStateRecord, attribute_id);
 
 	// Add joint distribution between state and customer demographics.
 	genrandSingleTableOneSidedCorrelatedJointDistribution(attribute_id,
@@ -290,7 +290,7 @@ ld_w_customer(void *row)
 int
 post_w_customer()
 {
-	serializeAttributeKeyRecord("customer_county", pCountyRecord);
-	serializeAttributeKeyRecord("customer_state", pStateRecord);
+	serializeAttributeKeyRecord("customer_county", g_w_customer_pCountyRecord);
+	serializeAttributeKeyRecord("customer_state", g_w_customer_pStateRecord);
 	return 0;
 }

--- a/code/tools/w_customer_address.c
+++ b/code/tools/w_customer_address.c
@@ -57,8 +57,8 @@ struct W_CUSTOMER_ADDRESS_TBL g_w_customer_address;
 
 static int * pLocationTypePermutation;
 
-struct ATTRIBUTE_KEY_RECORD * pCountyRecord;
-struct ATTRIBUTE_KEY_RECORD * pStateRecord;
+struct ATTRIBUTE_KEY_RECORD * g_w_customer_address_pCountyRecord;
+struct ATTRIBUTE_KEY_RECORD * g_w_customer_address_pStateRecord;
 
 /*
 * mk_customer_address
@@ -77,10 +77,10 @@ mk_w_customer_address (void* row, ds_key_t index)
 
 		int nKey = (int)get_rowcount(CUSTOMER_ADDRESS);
 		int nAttribute = distsize("fips_county");
-		pCountyRecord = initializeAttributeKeyRecord(nAttribute, nKey);
+		g_w_customer_address_pCountyRecord = initializeAttributeKeyRecord(nAttribute, nKey);
 
 		int nMaxAttribute = 52;
-		pStateRecord = initializeCharAttributeKeyRecord(nMaxAttribute, nKey);
+		g_w_customer_address_pStateRecord = initializeCharAttributeKeyRecord(nMaxAttribute, nKey);
 
 		bInit = 1;
 	}
@@ -104,8 +104,8 @@ mk_w_customer_address (void* row, ds_key_t index)
 	mk_address(&r->ca_address, CA_ADDRESS);
 
 	// Update information for populating joint distribution.
-	updateAttributeKeyRecord(pCountyRecord, g_address_county_id);
-	updateCharAttributeKeyRecord(pStateRecord, r->ca_address.state);
+	updateAttributeKeyRecord(g_w_customer_address_pCountyRecord, g_address_county_id);
+	updateCharAttributeKeyRecord(g_w_customer_address_pStateRecord, r->ca_address.state);
 	return (res);
 }
 
@@ -194,7 +194,7 @@ ld_w_customer_address(void *row)
 int
 post_w_customer_address()
 {
-	serializeAttributeKeyRecord("customer_address_county", pCountyRecord);
-	serializeAttributeKeyRecord("customer_address_state", pStateRecord);
+	serializeAttributeKeyRecord("customer_address_county", g_w_customer_address_pCountyRecord);
+	serializeAttributeKeyRecord("customer_address_state", g_w_customer_address_pStateRecord);
 	return 0;
 }

--- a/code/tools/w_customer_demographics.c
+++ b/code/tools/w_customer_demographics.c
@@ -51,7 +51,7 @@
 
 struct W_CUSTOMER_DEMOGRAPHICS_TBL g_w_customer_demographics;
 
-struct ATTRIBUTE_KEY_RECORD * pDemoRecord;
+struct ATTRIBUTE_KEY_RECORD * g_w_customer_pDemoRecord;
 
 /*
 * mk_customer_demographics
@@ -66,7 +66,7 @@ mk_w_customer_demographics (void* row, ds_key_t index)
 	if (!bInit) {
 		int nMaxAttribute = distsize("gender") * distsize("education") * distsize("marital_status");
 		int nKey = (int)get_rowcount(CUSTOMER_DEMOGRAPHICS);
-		pDemoRecord = initializeCharAttributeKeyRecord(nMaxAttribute, nKey);
+		g_w_customer_pDemoRecord = initializeCharAttributeKeyRecord(nMaxAttribute, nKey);
 		bInit = 1;
 	}
 
@@ -106,7 +106,7 @@ mk_w_customer_demographics (void* row, ds_key_t index)
 	strcpy(value, r->cd_gender);
 	strcat(value, r->cd_education_status);
 	strcat(value, r->cd_marital_status);
-	updateCharAttributeKeyRecord(pDemoRecord, value);
+	updateCharAttributeKeyRecord(g_w_customer_pDemoRecord, value);
 
 	return (res);
 }
@@ -184,6 +184,6 @@ ld_w_customer_demographics(void *row)
 int
 post_w_customer_demographics()
 {
-	serializeAttributeKeyRecord("customer_demographics", pDemoRecord);
+	serializeAttributeKeyRecord("customer_demographics", g_w_customer_pDemoRecord);
 	return 0;
 }

--- a/code/tools/w_household_demographics.c
+++ b/code/tools/w_household_demographics.c
@@ -59,7 +59,7 @@
 
 struct W_HOUSEHOLD_DEMOGRAPHICS_TBL g_w_household_demographics;
 
-struct ATTRIBUTE_KEY_RECORD * pDemoRecord;
+struct ATTRIBUTE_KEY_RECORD * g_w_household_pDemoRecord;
 
 /*
 * mk_household_demographics
@@ -82,7 +82,7 @@ mk_w_household_demographics (void* row, ds_key_t index)
 	if (!bInit) {
 		int nMaxAttribute = distsize("buy_potential") * distsize("dependent_count");
 		int nKey = (int)get_rowcount(HOUSEHOLD_DEMOGRAPHICS);
-		pDemoRecord = initializeCharAttributeKeyRecord(nMaxAttribute, nKey);
+		g_w_household_pDemoRecord = initializeCharAttributeKeyRecord(nMaxAttribute, nKey);
 		bInit = 1;
 	}
 
@@ -105,7 +105,7 @@ mk_w_household_demographics (void* row, ds_key_t index)
 	value[len1] = '0' + r->hd_dep_count;
 	value[len1 + 1] = '\0';
 	// Add skews to data
-	updateCharAttributeKeyRecord(pDemoRecord, value);
+	updateCharAttributeKeyRecord(g_w_household_pDemoRecord, value);
 
 	return (res);
 }
@@ -177,6 +177,6 @@ ld_w_household_demographics(void *pSrc)
 int
 post_w_household_demographics()
 {
-	serializeAttributeKeyRecord("household_demographics", pDemoRecord);
+	serializeAttributeKeyRecord("household_demographics", g_w_household_pDemoRecord);
 	return 0;
 }


### PR DESCRIPTION
This PR fixes compilation errors on Ubuntu 22.04 caused by linkage issues (fix #4).

Please see the commit log for a quick summary of changes.

# Notes

1. I hope I preserved the right semantics with "what to extern" vs. "what to split into its own global variable", but you should probably check.
2. Additionally, `y.tab.c` and `y.tab.h` are build-time files that have been checked into source control. They changed because I am using a slightly newer version of Bison (you use 3.5.1, I use 3.8.2). Do you want them in the PR?
```
 code/tools/y.tab.c | 1114 ++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------------------------------------------
 code/tools/y.tab.h |  120 ++++++++------
 2 files changed, 554 insertions(+), 680 deletions(-)
```

Thanks!